### PR TITLE
Fix: background styling bug from grid

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -5,9 +5,9 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <link rel="stylesheet" href="https://use.typekit.net/yfj4rfq.css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Aniaml Crossing: New Horizons NookHub</title>
-    <script type="module" crossorigin src="/NookHub/assets/index-ef30dd66.js"></script>
-    <link rel="stylesheet" href="/NookHub/assets/index-479c7570.css">
+    <title>Animal Crossing: New Horizons NookHub</title>
+    <script type="module" crossorigin src="/NookHub/assets/index-659d09a4.js"></script>
+    <link rel="stylesheet" href="/NookHub/assets/index-6c77f86e.css">
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -61,12 +61,15 @@ function App() {
   return (
     <>
       <Navigation />
-      <div className="card-container grid md:grid-cols-2 md:gap-7">
-        <NookCard icon={charIcons[0]} props={eventData}/>
-        <VisitorCard icon={charIcons[2]} getFish={currentFish} getBugs={currentBugs}/>
-        <DailyBday villager={bdayData}/>
+      <div className="card-container flex flex-wrap h-full">
+        <div className="flex flex-col w-full md:w-1/2 gap-7 p-4">
+          <NookCard className="w-96" icon={charIcons[0]} props={eventData}/>
+          <DailyBday villager={bdayData}/>
+        </div>
+        <div className="flex flex-col w-full md:w-1/2 gap-7 p-4">
+          <VisitorCard icon={charIcons[2]} getFish={currentFish} getBugs={currentBugs}/>
+        </div>
       </div>
-      
     </>
   )
 }

--- a/src/components/NookCard.css
+++ b/src/components/NookCard.css
@@ -1,6 +1,4 @@
 .nook-card {
-  width: 100%;
-  height: 26vh;
   padding: 1.25rem;
   background-color: #fdfdf2;
   border-radius: 26px;

--- a/src/components/VisitorCard.jsx
+++ b/src/components/VisitorCard.jsx
@@ -38,7 +38,6 @@ const VisitorCard = ({ icon, getFish, getBugs }) => {
                 <CritterCard critterType="Bugs" fauna={hemisphere ? 
                     getBugs.filter(bug => bug.north.months_array.includes(getMonth)) : 
                     getBugs.filter(bug => bug.south.months_array.includes(getMonth))} />
-
             </div>
         </div>
     )


### PR DESCRIPTION
## Description

Refactor CSS styling from the grid to flex by incorporating additional div containers to achieve desired two columns. 

## Related Issue

See UI updates for a visual of excess space in columns

## Acceptance Criteria

- [x] bridge the gap in space

## Type of Changes

Use a check for  ✓ the following type of changes: 

|     | Type                       |
| --- | -------------------------- |
|  ✓  | :bug: Bug fix              |
|    | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before

<img width="1073" alt="Screenshot 2023-04-07 at 3 02 58 PM" src="https://user-images.githubusercontent.com/93563580/230663268-79dcff12-d468-4bfe-b686-09a78b34acc3.png">

### After

<img width="1502" alt="Screenshot 2023-04-25 at 4 54 16 PM" src="https://user-images.githubusercontent.com/93563580/234401293-77a98c5d-9dbc-4624-8954-43f5535acfe4.png">


## Testing Steps / QA Criteria

Testing was done using dev browser tools 